### PR TITLE
fixed password match and reset

### DIFF
--- a/register/forms.py
+++ b/register/forms.py
@@ -12,6 +12,10 @@ class EmailPrefilledMixin:
         if 'email' in self.fields:
             self.fields['email'].widget = Display()
 
+    def flatten_dict(self, dict_):
+        return {k: v[0] if isinstance(v, list) else v
+                for k, v in dict_.items()}
+
 
 class EmailForm(forms.Form):
     email = forms.EmailField(required=True)
@@ -24,8 +28,8 @@ class LoginForm(EmailPrefilledMixin, AuthenticationForm):
         email = kwargs['initial'].get('email')
         kwargs['initial']['username'] = email
         if 'data' in kwargs:
-            kwargs['data'] = dict(kwargs['data'])
             kwargs['data']['username'] = email
+            kwargs['data'] = self.flatten_dict(kwargs['data'])
         super().__init__(*args, **kwargs)
         self.fields['username'].widget = Display()
 
@@ -33,8 +37,9 @@ class LoginForm(EmailPrefilledMixin, AuthenticationForm):
 class RegisterForm(EmailPrefilledMixin, RegistrationForm):
     def __init__(self, *args, **kwargs):
         if 'data' in kwargs and 'password1' in kwargs['data']:
-            kwargs['data'] = dict(kwargs['data'])
+            kwargs['data'] = self.flatten_dict(kwargs['data'])
             kwargs['data']['password2'] = kwargs['data']['password1']
+
         super().__init__(*args, **kwargs)
         self.fields['password2'].required = False
         self.fields['password2'].widget.input_type = 'hidden'

--- a/register/models.py
+++ b/register/models.py
@@ -45,3 +45,6 @@ class User(AbstractBaseUser):
 
     def has_perm(self, *args):
         return self.is_staff
+
+    def get_full_name(self):
+        return self.email


### PR DESCRIPTION
- When registering, a password being _mypass_ was saved as _['mypass']_.
- When requesting password reset, an error 500 was risen due to missing `User.get_full_name()`.